### PR TITLE
Prevent uses of node reference from being assigned default attributes if already declared.

### DIFF
--- a/js/dotgraph.coffee
+++ b/js/dotgraph.coffee
@@ -188,7 +188,8 @@ class DotGraph
                 when 'edge_stmt'
                     # first make sure all the nodes are added
                     for node in tree.edge_list
-                        if node.type is 'node_id'
+                        # Only add a node if it doesn't already exist -- must not merge new attr state
+                        if node.type is 'node_id' and !@nodes[node.id]?
                             walk({type: 'node_stmt', node_id: node, attr_list: []}, state, currentParentGraph)
                         else if node.type is 'subgraph'
                             walk(node, state, currentParentGraph)

--- a/js/dotgraph.js
+++ b/js/dotgraph.js
@@ -294,7 +294,7 @@ DotGraph = (function() {
           _ref1 = tree.edge_list;
           for (_j = 0, _len1 = _ref1.length; _j < _len1; _j++) {
             node = _ref1[_j];
-            if (node.type === 'node_id') {
+            if (node.type === 'node_id' && !(_this.nodes[node.id] != null)) {
               walk({
                 type: 'node_stmt',
                 node_id: node,


### PR DESCRIPTION
Scenario:

``` dot
z;
node [gender=male]; y;
node [gender=female]; x;
z -- x;
z -- y;
```

Intent for z to have no (or empty-valued) gender attribute, as specified in para 1, "Lexical and Semantic Notes" of the
DOT Language Specification.

Previous behaviour would assign z gender=female.
