### PR TITLE
Fixing couple bugs

### DIFF
--- a/js/graphviz-dot-grammar.pegjs
+++ b/js/graphviz-dot-grammar.pegjs
@@ -76,8 +76,7 @@ STRING
 
 NUMBER "NUMBER"
   = n:("-"? ("." [0-9]+ / [0-9]+("." [0-9]*)?)) { 
-       flatten = function(v){ return typeof v === 'string' ? v : v.map(flatten).join(''); }
-       return parseFloat(flatten(n)); 
+       return parseFloat(text()); 
     }
 
 /* html strings are enclosed in <>. The inside of those strings is xml.  All we care about
@@ -94,7 +93,7 @@ html_char
 
 QUOTED_STRING
   = '"' '"' {return "";}
-  / v:('"' chars ("\\" NEWLINE chars)? '"') rest:(_ '+' _ v:QUOTED_STRING {return v})? { return v[1] + rest; }
+  / v:('"' chars ("\\" NEWLINE chars)? '"') rest:(_ '+' _ v:QUOTED_STRING {return v})? { return rest === null ? v[1] : (v[1] + rest); }
 
 chars
   = chars:char+ { return chars.join(""); }


### PR DESCRIPTION
This probably worked before, but with latest version of peg.js (0.8.0) I see parser does not correctly parses basic things.
# Bug 1

This graph: `graph 42 {}` will throw an error: `Cannot read property 'map' of null`. This is addressed by replacing `flatten` with build-in `text()` function.
# Bug 2

`graph "G" {}` will have `id` "Gnull", instead of G. This is addressed by checking rest against null in QUOTED_STRING
